### PR TITLE
fix(i18n): replace "}" in resources

### DIFF
--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -19,52 +19,51 @@ const resources = {
       },
       button: {
         addNewCompany: '+ Add New Company',
-
-        altText: {
-          logo: 'Logo',
-          key: 'Key',
-          lock: 'Lock',
+      },
+      altText: {
+        logo: 'Logo',
+        key: 'Key',
+        lock: 'Lock',
+      },
+      notFound: {
+        header: 'Page Not Found',
+        errorMessage: 'The page you are looking for does not exist.',
+        button: 'Back to app',
+      },
+      auth: {
+        loginLinkSuccess:
+          'Message successfully sent to {{email}}, please check your email.',
+        loginLinkFailure:
+          'Failed to send the login link. Please try again later.',
+        userNotExistError:
+          "User with this email doesn't exist. Please try again later.",
+        unknownError: 'An unknown error occurred.',
+        invalidExpiredLink: 'Invalid or expired link.',
+        verificationError:
+          'An error occurred during verification. Please try again.',
+      },
+      signin: {
+        welcomeMessage: 'Welcome to Smartporters! 👋',
+        instructions: 'Please sign in to your account and start the delivery',
+        email: 'Email',
+        submit: 'Sign In',
+        error: {
+          invalidCredentials: 'Please enter valid credentials.',
+          accountLocked: 'Too many attempts, try later.',
+          invalidFormat: 'Email format is incorrect.',
+          incorrectEmail: 'Email incorrect.',
+          required: 'Email is required.',
         },
-        notFound: {
-          header: 'Page Not Found',
-          errorMessage: 'The page you are looking for does not exist.',
-          button: 'Back to app',
-        },
-        auth: {
-          loginLinkSuccess:
-            'Message successfully sent to {{email}}, please check your email.',
-          loginLinkFailure:
-            'Failed to send the login link. Please try again later.',
-          userNotExistError:
-            "User with this email doesn't exist. Please try again later.",
-          unknownError: 'An unknown error occurred.',
-          invalidExpiredLink: 'Invalid or expired link.',
-          verificationError:
-            'An error occurred during verification. Please try again.',
-        },
-        signin: {
-          welcomeMessage: 'Welcome to Smartporters! 👋',
-          instructions: 'Please sign in to your account and start the delivery',
-          email: 'Email',
-          submit: 'Sign In',
-          error: {
-            invalidCredentials: 'Please enter valid credentials.',
-            accountLocked: 'Too many attempts, try later.',
-            invalidFormat: 'Email format is incorrect.',
-            incorrectEmail: 'Email incorrect.',
-            required: 'Email is required.',
-          },
-        },
-        navigation: {
-          dashboard: 'Dashboard',
-          orders: 'Orders',
-          routes: 'Routes',
-          settings: 'Settings',
-          companyList: 'Company List',
-        },
-        orders: {
-          welcome: 'Orders page',
-        },
+      },
+      navigation: {
+        dashboard: 'Dashboard',
+        orders: 'Orders',
+        routes: 'Routes',
+        settings: 'Settings',
+        companyList: 'Company List',
+      },
+      orders: {
+        welcome: 'Orders page',
       },
     },
   },


### PR DESCRIPTION
## Describe your changes

- I replace "}" in resources.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://codecraftersintership.atlassian.net/browse/SCRUM-60?focusedCommentId=10012&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-10012)

### **General**

- [ ] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [ ] Performed a self-review of my code
- [ ] Types for input and output parameters
- [ ] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [ ] Don't have magic numbers
- [ ] Compare only with constants not with strings
- [ ] No ternary operator inside the ternary operator
- [ ] Don't have commented code
- [ ] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [ ] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [ ] No hardcoded values
- [ ] covered by tests
- [ ] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [ ] Components and business logic are separated
- [ ] Colors, Font Size, and Font Name is on the theme or in the constants
- [ ] No text in the components, use i18n approach
- [ ] No inline styles
- [ ] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.
