### PR TITLE
feat: resized pages and rows

### DIFF
--- a/src/components/RoutesRow/index.tsx
+++ b/src/components/RoutesRow/index.tsx
@@ -51,7 +51,7 @@ const RoutesRow: React.FC<RoutesRowProps> = ({
   return (
     <Box
       display="grid"
-      gridTemplateColumns="1fr 1.5fr 2fr 1fr 1.5fr 1fr 1.5fr 1.5fr"
+      gridTemplateColumns="1fr 1.5fr 2fr 1fr 1.5fr 1fr 1fr 1.5fr"
       padding="8px 16px"
       gap="16px"
       borderBottom={`1px solid ${COLORS.text.border}`}

--- a/src/pages/CreateRoute/SecondStage/components/OrderManagementCard/styles.ts
+++ b/src/pages/CreateRoute/SecondStage/components/OrderManagementCard/styles.ts
@@ -9,7 +9,7 @@ export const orderRow: SxProps<Theme> = {
   alignItems: 'center',
   justifyContent: 'space-between',
   background: COLORS.white,
-  padding: '10px 25px',
+  padding: '5px 25px',
   border: '0px',
   color: COLORS.text.medium,
 

--- a/src/pages/CreateRoute/SecondStage/styles.ts
+++ b/src/pages/CreateRoute/SecondStage/styles.ts
@@ -3,14 +3,15 @@ import { SxProps, Theme } from '@mui/material';
 export const paginationWrapper: SxProps<Theme> = {
   width: '1126px',
   marginTop: '20px',
-  marginBottom: '36px',
+  marginBottom: '20px',
   display: 'flex',
   justifyContent: 'flex-end',
 };
 
 export const searchRow: SxProps<Theme> = {
   width: '1126px',
+  marginBottom: '5px',
   display: 'flex',
   justifyContent: 'space-between',
-  alignItems: 'baseline',
+  alignItems: 'center',
 };

--- a/src/pages/Orders/components/OrderItem/styles.ts
+++ b/src/pages/Orders/components/OrderItem/styles.ts
@@ -10,7 +10,7 @@ export const orderRow: (isNew: boolean) => SxProps<Theme> = (isNew) => {
     alignItems: 'center',
     justifyContent: 'space-between',
     background: isNew ? COLORS.lightPurple : COLORS.white,
-    padding: '10px 25px',
+    padding: '5px 25px',
     border: isNew ? `1px solid ${COLORS.purple}` : '0px',
     color: COLORS.text.medium,
 
@@ -23,7 +23,7 @@ export const orderRow: (isNew: boolean) => SxProps<Theme> = (isNew) => {
 
 export const customerBlock: SxProps<Theme> = {
   width: '250px',
-  padding: '10px 20px',
+  padding: '5px 20px',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-evenly',

--- a/src/pages/Orders/components/SortingRow/styles.ts
+++ b/src/pages/Orders/components/SortingRow/styles.ts
@@ -5,9 +5,9 @@ import { FONT } from '@/constants/font';
 
 export const sortingRow: SxProps<Theme> = {
   width: '1238px',
-  marginTop: '15px',
+  marginTop: '10px',
   background: COLORS.white,
-  padding: '10px 25px',
+  padding: '5px 25px',
   display: 'flex',
   justifyContent: 'space-between',
 };

--- a/src/pages/TeamManagment/styles.ts
+++ b/src/pages/TeamManagment/styles.ts
@@ -30,15 +30,15 @@ export const searchField: SxProps<Theme> = {
   '& .MuiOutlinedInput-root': {
     height: '100%',
   },
-  '& .MuiFormLabel-root': {
-    transform: (theme) =>
-      theme.typography.htmlFontSize === 16
-        ? 'translate(14px, -9px) scale(0.75)'
-        : 'translate(14px, 9px) scale(1)',
+  '& .MuiInputLabel-root': {
+    transform: 'translate(14px, 9px) scale(1)',
+    transition: 'transform 200ms ease-out',
   },
-  '& .MuiFormLabel-root.MuiInputLabel-root.Mui-focused': {
+  '& .MuiInputLabel-root.Mui-focused': {
     transform: 'translate(14px, -9px) scale(0.75)',
-    maxWidth: 'calc(133% - 32px)',
+  },
+  '& .MuiInputLabel-root:not(.Mui-focused):not(.MuiInputLabel-shrink)': {
+    transform: 'translate(14px, 9px) scale(1)',
   },
 };
 

--- a/src/pages/components/CreateRouteBtns/styles.ts
+++ b/src/pages/components/CreateRouteBtns/styles.ts
@@ -2,7 +2,7 @@ import { SxProps, Theme } from '@mui/material/styles';
 
 export const wrapper: SxProps<Theme> = {
   width: '1128px',
-  marginTop: '36px',
+  marginTop: '18px',
   display: 'flex',
   justifyContent: 'space-between',
 };

--- a/src/pages/components/CreateRouteProgressBar/styles.ts
+++ b/src/pages/components/CreateRouteProgressBar/styles.ts
@@ -3,7 +3,7 @@ import { SxProps, Theme } from '@mui/material';
 
 export const progressBarStyles: SxProps<Theme> = {
   width: '1127px',
-  marginBottom: '36px',
+  marginBottom: '18px',
   display: 'flex',
   justifyContent: 'space-between',
   backgroundColor: COLORS.white,


### PR DESCRIPTION
## Describe your changes

- Resize pages and table rows

![photo_2025-01-02_20-22-19](https://github.com/user-attachments/assets/0f7c1bc9-dac2-4f57-8c7f-fe204e5d4666)
![photo_2025-01-02_20-22-22](https://github.com/user-attachments/assets/474ec43d-98ab-42a1-9a90-25753772dbee)
![photo_2025-01-02_20-22-11](https://github.com/user-attachments/assets/bc6c4e9e-3da1-4e2d-88fc-5c382eabdc49)
![photo_2025-01-02_20-22-222](https://github.com/user-attachments/assets/91fa1c2a-ac2f-4951-817c-92b963fc7c3e)
![photo_2025-01-02_20-22-08](https://github.com/user-attachments/assets/288912bd-2aec-4b81-868e-c792885c0944)
![photo_2025-01-02_20-21-27](https://github.com/user-attachments/assets/6bc623ed-3785-421a-80de-1477e26477b5)
![photo_2025-01-02_20-22-17](https://github.com/user-attachments/assets/80497abf-575a-4511-8618-390c613890d0)



## Issue ticket code (and/or) and link

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [x] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
